### PR TITLE
Fix: Not working after reopen

### DIFF
--- a/android/src/main/java/io/github/ponnamkarthik/qrcodereader/QRCodeReaderPlugin.java
+++ b/android/src/main/java/io/github/ponnamkarthik/qrcodereader/QRCodeReaderPlugin.java
@@ -24,7 +24,6 @@ public class QRCodeReaderPlugin implements MethodCallHandler, ActivityResultList
 
   private static final int REQUEST_CODE_SCAN_ACTIVITY = 2777;
   private static final int REQUEST_CODE_CAMERA_PERMISSION = 3777;
-  private static QRCodeReaderPlugin instance;
 
   private FlutterActivity activity;
   private Result pendingResult;
@@ -36,15 +35,12 @@ public class QRCodeReaderPlugin implements MethodCallHandler, ActivityResultList
   }
 
   public static void registerWith(PluginRegistry.Registrar registrar) {
-    if (instance == null) {
-      final MethodChannel channel = new MethodChannel(registrar.messenger(), CHANNEL);
-      instance = new QRCodeReaderPlugin((FlutterActivity) registrar.activity());
-      registrar.addActivityResultListener(instance);
-      registrar.addRequestPermissionsResultListener(instance);
-      channel.setMethodCallHandler(instance);
-    }
+    final MethodChannel channel = new MethodChannel(registrar.messenger(), CHANNEL);
+    QRCodeReaderPlugin instance = new QRCodeReaderPlugin((FlutterActivity) registrar.activity());
+    registrar.addActivityResultListener(instance);
+    registrar.addRequestPermissionsResultListener(instance);
+    channel.setMethodCallHandler(instance);
   }
-
 
   @Override
   public void onMethodCall(MethodCall call, Result result) {


### PR DESCRIPTION
Steps to reproduce:
1. Create a simple app that has a button to open the qr reader
2. Run the app on Android
3. Click the button and see the camera opens
4. Use the back button to close the app (NOT FORCE CLOSE)
5. Reopen the app by clicking the launcher icon
6. Click on the button again to open the qr reader -> Nothing happens (console says that no plugin is registered on channel `qrcodereader`).

The reason for that error is:
The plugins are cleaned up after the app is closed. But the instance you keep is not cleaned up. So when the app opens again, it tries to register all plugins. But because you still have the instance, you don't do anything. So the plugin does not get registered.

With the fix it will work correctly (tested it locally).

Would be nice if this gets merged in soon :). Thx!