### PR TITLE
Fix Example import using OLD repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Flutter plugin for reading QR Codes with the camera.
 ### Example
 
 ``` dart
-import 'package:qrcode_reader/QRCodeReader.dart';
+import 'package:qr_reader/qr_reader.dart';
 ```
 
 ``` dart


### PR DESCRIPTION
The example uses a "wrong" import. It uses the import for the other plugin that you cloned.